### PR TITLE
fix : springdoc api 정렬을 method별로 작업할 수 있게 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,10 +32,10 @@ springdoc:
   swagger-ui:
     path: /service
     tags-sorter: alpha
-    operations-sorter: alpha
+    operations-sorter: method
   api-docs:
     path: /service/v3/api-docs
     groups:
       enabled: true
-    cache:
-      disabled: true
+  cache:
+    disabled: true


### PR DESCRIPTION
application.yml의 springdoc.swagger-ui.operations-sorter의 값을 alpha에서 method로 변경하여 알파벳 순으로 정렬하는것이 아니라 method별로 정렬하게 바꿈