### PR TITLE
Feature/add sensor

### DIFF
--- a/http/SensorTest.http
+++ b/http/SensorTest.http
@@ -2,3 +2,17 @@
 GET localhost:8090/admin/sensor
 X-USER-ID: admin
 Content-Type: application/json
+
+
+### 센서 등록
+POST localhost:8090/admin/sensor
+content-type: application/json
+X-USER-ID : admin
+
+{
+  "name" : "sensor1",
+  "modelName" : "모델명",
+  "channel" : 54,
+  "ip" : "0.0.0.1",
+  "port" : "1883"
+}

--- a/src/main/java/live/ioteatime/apiservice/advice/AdminControllerAdvice.java
+++ b/src/main/java/live/ioteatime/apiservice/advice/AdminControllerAdvice.java
@@ -1,0 +1,15 @@
+package live.ioteatime.apiservice.advice;
+
+import live.ioteatime.apiservice.exception.SensorNotSupportedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class AdminControllerAdvice {
+    @ExceptionHandler(SensorNotSupportedException.class)
+    public ResponseEntity<String> sensorNotSupported(SensorNotSupportedException e){
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+}

--- a/src/main/java/live/ioteatime/apiservice/controller/AdminController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/AdminController.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import live.ioteatime.apiservice.annotation.AdminOnly;
 import live.ioteatime.apiservice.domain.Sensor;
+import live.ioteatime.apiservice.dto.AddSensorRequest;
 import live.ioteatime.apiservice.dto.UserDto;
 import live.ioteatime.apiservice.service.AdminService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,6 +55,17 @@ public class AdminController {
         return ResponseEntity.ok(adminService.getSensors());
     }
 
+
+    /**
+     * 어드민만 사용할 수 있는 명령어이며 새 센서를 추가하는 핸들러다.
+     * @return 등록 완료한 센서 아이디
+     */
+    @PostMapping("/sensor")
+    @AdminOnly
+    public ResponseEntity<String> addMqttSensor(@RequestHeader(X_USER_ID) String userId, @RequestBody AddSensorRequest addSensorRequest){
+        int registeredSensorId = adminService.addMqttSensor(userId, addSensorRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body("Created. id="+registeredSensorId);
+    }
 
     /**
      * 어드민만 사용할 수 있는 명령어이며 회원가입한 유저의 권한을 GUEST에서 USER로 바꿔주는 컨트롤러다.

--- a/src/main/java/live/ioteatime/apiservice/controller/UserController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/UserController.java
@@ -77,7 +77,7 @@ public class UserController {
      * @param userDto 수정될 유저의 정보를 가지고 있는 Dto 클래스
      * @return HttpStatus 200 OK
      */
-    @PutMapping
+    @PutMapping("/update-user")
     @Operation(summary = "유저 정보를 업데이트하는 API", description = "유저 정보를 업데이트합니다.")
     public ResponseEntity<String> updateUser(@RequestHeader(X_USER_ID) String userId, @RequestBody UserDto userDto){
         return ResponseEntity.ok(userService.updateUser(userDto));

--- a/src/main/java/live/ioteatime/apiservice/domain/Organization.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/Organization.java
@@ -6,7 +6,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
-@Table(name = "organization")
+@Table(name = "organizations")
 public class Organization {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/live/ioteatime/apiservice/domain/Organization.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/Organization.java
@@ -3,7 +3,6 @@ package live.ioteatime.apiservice.domain;
 import lombok.Getter;
 
 import javax.persistence.*;
-import java.math.BigInteger;
 
 @Entity
 @Getter
@@ -15,7 +14,7 @@ public class Organization {
     private int id;
     private String name;
     @Column(name = "electricity_budget")
-    private BigInteger electricityBudget;
+    private Long electricityBudget;
     @Column(name = "organization_code")
     private String organizationCode;
 }

--- a/src/main/java/live/ioteatime/apiservice/domain/Sensor.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/Sensor.java
@@ -13,12 +13,23 @@ import javax.persistence.*;
 @Setter
 public class Sensor {
     @Id
-    @Column(name = "sensor_number")
+    @Column(name = "sensor_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int sensorNumber;
+    private int id;
     @Column(name = "sensor_name")
-    private String sensorName;
+    private String name;
+    @Column(name = "sensor_model_name")
+    private String modelName;
+    @Column
+    private int channel;
+    @Column
+    private String ip;
+    @Column
+    private String port;
     @Column
     @Enumerated(EnumType.STRING)
     private Alive alive;
+    @JoinColumn(name = "organization_id")
+    @ManyToOne
+    private Organization organization;
 }

--- a/src/main/java/live/ioteatime/apiservice/domain/SupportedSensor.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/SupportedSensor.java
@@ -1,0 +1,23 @@
+package live.ioteatime.apiservice.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "supported_sensors")
+@Getter @Setter @NoArgsConstructor
+public class SupportedSensor {
+    @Id
+    @Column(name = "sensor_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(name = "sensor_model_name")
+    private String modelName;
+
+    @Column
+    private int channel;
+}

--- a/src/main/java/live/ioteatime/apiservice/domain/Topic.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/Topic.java
@@ -1,0 +1,35 @@
+package live.ioteatime.apiservice.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "topics")
+@Getter @Setter @NoArgsConstructor
+public class Topic {
+    @EmbeddedId
+    private Pk pk;
+
+    @MapsId("sensorId")
+    @JoinColumn
+    @ManyToOne
+    private Sensor sensor;
+
+    @Column
+    private String topic;
+
+    @Embeddable
+    @NoArgsConstructor @AllArgsConstructor
+    @EqualsAndHashCode
+    @Getter @Setter
+    public static class Pk implements Serializable {
+
+        @Column
+        private int channel;
+
+        @Column(name = "sensor_id")
+        private int sensorId;
+    }
+}

--- a/src/main/java/live/ioteatime/apiservice/dto/AddSensorRequest.java
+++ b/src/main/java/live/ioteatime/apiservice/dto/AddSensorRequest.java
@@ -1,0 +1,15 @@
+package live.ioteatime.apiservice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter @Setter
+public class AddSensorRequest {
+    private String name;
+    private String modelName;
+    private int channel;
+    private String ip;
+    private String port;
+}

--- a/src/main/java/live/ioteatime/apiservice/dto/OrganizationDto.java
+++ b/src/main/java/live/ioteatime/apiservice/dto/OrganizationDto.java
@@ -16,5 +16,5 @@ public class OrganizationDto {
     @Schema(description = "조직 이름입니다.")
     private String name;
     @Schema(description = "조직 ADMIN이 설정한 이번 달 목표 전기 요금 값입니다.")
-    private BigInteger electricityBudget;
+    private Long electricityBudget;
 }

--- a/src/main/java/live/ioteatime/apiservice/exception/SensorNotSupportedException.java
+++ b/src/main/java/live/ioteatime/apiservice/exception/SensorNotSupportedException.java
@@ -1,0 +1,7 @@
+package live.ioteatime.apiservice.exception;
+
+public class SensorNotSupportedException extends RuntimeException {
+    public SensorNotSupportedException() {
+        super("지원하지 않는 디바이스입니다.");
+    }
+}

--- a/src/main/java/live/ioteatime/apiservice/repository/SupportedSensorRepository.java
+++ b/src/main/java/live/ioteatime/apiservice/repository/SupportedSensorRepository.java
@@ -1,0 +1,8 @@
+package live.ioteatime.apiservice.repository;
+
+import live.ioteatime.apiservice.domain.SupportedSensor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SupportedSensorRepository extends JpaRepository<SupportedSensor, Integer> {
+    boolean existsByModelName(String modelName);
+}

--- a/src/main/java/live/ioteatime/apiservice/service/AdminService.java
+++ b/src/main/java/live/ioteatime/apiservice/service/AdminService.java
@@ -1,6 +1,7 @@
 package live.ioteatime.apiservice.service;
 
 import live.ioteatime.apiservice.domain.Sensor;
+import live.ioteatime.apiservice.dto.AddSensorRequest;
 import live.ioteatime.apiservice.dto.UserDto;
 
 import java.util.List;
@@ -13,4 +14,5 @@ public interface AdminService {
     List<Sensor> getSensors();
 
     UserDto updateUserRole(String userId);
+    int addMqttSensor(String userId, AddSensorRequest request);
 }

--- a/src/main/java/live/ioteatime/apiservice/service/impl/AdminServiceImpl.java
+++ b/src/main/java/live/ioteatime/apiservice/service/impl/AdminServiceImpl.java
@@ -1,26 +1,32 @@
 package live.ioteatime.apiservice.service.impl;
 
-import live.ioteatime.apiservice.domain.Role;
-import live.ioteatime.apiservice.domain.Sensor;
-import live.ioteatime.apiservice.domain.User;
+import live.ioteatime.apiservice.domain.*;
+import live.ioteatime.apiservice.dto.AddSensorRequest;
 import live.ioteatime.apiservice.dto.UserDto;
+import live.ioteatime.apiservice.exception.OrganizationNotFoundException;
+import live.ioteatime.apiservice.exception.SensorNotSupportedException;
 import live.ioteatime.apiservice.exception.UserNotFoundException;
 import live.ioteatime.apiservice.repository.AdminRepository;
 import live.ioteatime.apiservice.repository.SensorRepository;
+import live.ioteatime.apiservice.repository.SupportedSensorRepository;
 import live.ioteatime.apiservice.service.AdminService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class AdminServiceImpl implements AdminService {
 
     private final AdminRepository adminRepository;
     private final SensorRepository sensorRepository;
+    private final SupportedSensorRepository supportedSensorRepository;
 
     @Override
     public List<UserDto> getGuestUsers() {
@@ -59,5 +65,33 @@ public class AdminServiceImpl implements AdminService {
         BeanUtils.copyProperties(user, userDto, "password");
         adminRepository.save(user);
         return userDto;
+    }
+
+    /**
+     * 서버에서 지원하는 센서 모델인지 체크 후 등록 가능한 경우, 센서를 데이터베이스에 등록합니다.
+     * @param userId 어드민 유저 아이디
+     * @param request 센서 등록 요청 폼 데이터
+     * @return
+     */
+    @Override
+    public int addMqttSensor(String userId, AddSensorRequest request) {
+
+        log.debug("Add sensor request - model_name: {}", request.getModelName());
+        if(!supportedSensorRepository.existsByModelName(request.getModelName())){
+            throw new SensorNotSupportedException();
+        }
+        Organization organization = adminRepository.findById(userId).get().getOrganization();
+        if(Objects.isNull(organization)) {
+            throw new OrganizationNotFoundException();
+        }
+
+        Sensor sensor = new Sensor();
+        BeanUtils.copyProperties(request, sensor);
+        sensor.setAlive(Alive.DOWN);
+        sensor.setOrganization(organization);
+
+        sensorRepository.save(sensor);
+
+        return sensor.getId();
     }
 }


### PR DESCRIPTION
# 1. 사이드바, 마이페이지 오류 해결

### 회원 정보 수정 엔드포인트 변경

“PUT /users” → “PUT /users/update-user” 로 변경하였습니다.

### Organization 엔티티 및 Dto 필드 타입 변경

BigInteger electricityBudget → Long electricityBudget 으로 변경하였습니다.

# 2. 테이블(엔티티) 추가

### (1) supported_sensors

우리 서비스에서 제공하는 센서 종류를 저장하는 테이블입니다.

ADMIN 유저는 이 테이블에 있는 종류의 센서만 등록 가능합니다.

#### 필드

- sensor_id (pk) : 아이디(auto increment)
- sensor_model_name : 센서 모델명
- channel : 센서의 최대 채널 수

### (2) sensors

ADMIN 사용자가 등록한 센서 정보입니다.

#### 필드

- sensor_id (pk) : 아이디(auto increment)
- sensor_name : 사용자 지정 센서이름 (alias라고 생각하면 됨)
- sensor_model_name : 센서 모델명. supported_sensors 테이블에 존재하는 이름이어야 합니다.
- channel : 사용자가 사용할 채널 개수
- ip : 센서(mqtt broker) 아이피
- port : 센서(mqtt broker)  포트
- alive : 센서가 살아있는지 여부 (UP, DOWN)
- organization_id (fk) : 센서를 보유한 조직 아이디

### (3) topics

센서는 여러 개의 채널(포트)을 가지고 있고, 센서 채널 하나당 하나의 토픽을 가지게 됩니다.

`topics` 테이블에는 ADMIN 사용자가 등록한 센서의 토픽 정보를 저장합니다.

(토픽은 Mqtt broker인 센서가 데이터를 publish할 때 사용하는 토픽입니다.)

#### 필드

- sensor_id (pk) : 센서 아이디
- channel (pk) : 채널번호
- topic : 토픽

### 추가한 부분

![image](https://github.com/nhnacademy-aiot1-5/api-service/assets/124178635/265b0144-6a97-4880-b2c1-21919d8e39a4)


# 3. 엔드포인트 구현

GET /admin/sensor : ADMIN 사용자가 입력한 센서 정보를 sensors 테이블에 저장합니다.