### PR TITLE
Feature/dashboard linechart

### DIFF
--- a/http/DailyElectricityTest.http
+++ b/http/DailyElectricityTest.http
@@ -3,3 +3,6 @@ GET localhost:8090/daily/electricities?localDateTime=2024-04-28T16:18:00&channel
 
 ###
 GET localhost:8090/hourly/electricities/total?organizationId=1
+
+###
+GET localhost:8090/daily/electricities/total?localDateTime=2024-04-12T16:18:00&organizationId=1

--- a/src/main/java/live/ioteatime/apiservice/controller/DailyElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/DailyElectricityController.java
@@ -56,7 +56,7 @@ public class DailyElectricityController {
      */
     @GetMapping("/electricities/total")
     @VerifyOrganization
-    public ResponseEntity<List<ElectricityResponseDto>> getMontlyTotalElectricities(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    public ResponseEntity<List<ElectricityResponseDto>> getcurrentMonthTotalElectricities(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                                                                                     @RequestParam("localDateTime") LocalDateTime localDateTime,
                                                                                     @RequestParam("organizationId") int organizationId){
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/live/ioteatime/apiservice/controller/DailyElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/DailyElectricityController.java
@@ -1,10 +1,12 @@
 package live.ioteatime.apiservice.controller;
 
+import live.ioteatime.apiservice.annotation.VerifyOrganization;
 import live.ioteatime.apiservice.dto.electricity.ElectricityRequestDto;
 import live.ioteatime.apiservice.dto.electricity.ElectricityResponseDto;
 import live.ioteatime.apiservice.service.ElectricityService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,6 +48,21 @@ public class DailyElectricityController {
                 new ElectricityRequestDto(localDateTime, channelId)));
     }
 
+    /**
+     * 지정된 날짜에 해당하는 모든 월별 전력 사용량 데이터를 조회합니다.
+     * 요청을 보내는 사용자 조직의 모든 채널의 총 사용량 합을 반환합니다.
+     *
+     * @return
+     */
+    @GetMapping("/electricities/total")
+    @VerifyOrganization
+    public ResponseEntity<List<ElectricityResponseDto>> getMontlyTotalElectricities(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+                                                                                    @RequestParam("localDateTime") LocalDateTime localDateTime,
+                                                                                    @RequestParam("organizationId") int organizationId){
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(electricityService.getTotalElectricitiesByDate(localDateTime, organizationId));
+    }
+
     @GetMapping("electricity/last")
     public ResponseEntity<ElectricityResponseDto> getLastDayElectricity(){
         return ResponseEntity.ok(electricityService.getLastElectricity());
@@ -55,4 +72,6 @@ public class DailyElectricityController {
     public ResponseEntity<ElectricityResponseDto> getCurrentDayElectricity(){
         return ResponseEntity.ok(electricityService.getCurrentElectricity());
     }
+
+
 }

--- a/src/main/java/live/ioteatime/apiservice/controller/MonthlyElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/MonthlyElectricityController.java
@@ -7,10 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -62,7 +59,7 @@ public class MonthlyElectricityController {
      * @return 조회된 모든 월별 전력 사용량 데이터를 {@link ElectricityResponseDto} 객체의 리스트로 반환합니다.
      */
     @GetMapping("/electricities")
-    public ResponseEntity<List<ElectricityResponseDto>> getMonthlyElectricies(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    public ResponseEntity<List<ElectricityResponseDto>> getMonthlyElectricties(@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
                                                                               @RequestParam LocalDateTime localDateTime,
                                                                               @RequestParam int channelId) {
         return ResponseEntity.ok(electricityService.getElectricitiesByDate(

--- a/src/main/java/live/ioteatime/apiservice/controller/PredictedElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/PredictedElectricityController.java
@@ -24,7 +24,7 @@ public class PredictedElectricityController {
     @GetMapping
     public ResponseEntity<List<PreciseElectricityResponseDto>> getMonthlyPredictedValues(
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            @RequestParam("LocalDateTime") LocalDateTime requestTime){
+            @RequestParam("requestTime") LocalDateTime requestTime){
         return ResponseEntity.status(HttpStatus.OK)
                 .body(predictedElectricityService.getCurrentMonthPredictions(requestTime));
     }

--- a/src/main/java/live/ioteatime/apiservice/dto/electricity/ElectricityResponseDto.java
+++ b/src/main/java/live/ioteatime/apiservice/dto/electricity/ElectricityResponseDto.java
@@ -1,5 +1,6 @@
 package live.ioteatime.apiservice.dto.electricity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ElectricityResponseDto {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime time;
     private long kwh;
     private Long bill;

--- a/src/main/java/live/ioteatime/apiservice/dto/electricity/ElectricityResponseDto.java
+++ b/src/main/java/live/ioteatime/apiservice/dto/electricity/ElectricityResponseDto.java
@@ -12,5 +12,5 @@ import java.time.LocalDateTime;
 public class ElectricityResponseDto {
     private LocalDateTime time;
     private long kwh;
-    private long bill;
+    private Long bill;
 }

--- a/src/main/java/live/ioteatime/apiservice/dto/electricity/PreciseElectricityResponseDto.java
+++ b/src/main/java/live/ioteatime/apiservice/dto/electricity/PreciseElectricityResponseDto.java
@@ -1,15 +1,15 @@
 package live.ioteatime.apiservice.dto.electricity;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class PreciseElectricityResponseDto {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime time;
     private Double kwh;
 }

--- a/src/main/java/live/ioteatime/apiservice/repository/ChannelRepository.java
+++ b/src/main/java/live/ioteatime/apiservice/repository/ChannelRepository.java
@@ -1,6 +1,7 @@
 package live.ioteatime.apiservice.repository;
 
 import live.ioteatime.apiservice.domain.Channel;
+import live.ioteatime.apiservice.domain.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,4 +16,6 @@ public interface ChannelRepository extends JpaRepository<Channel, Integer> {
     int countBySensor_Id(int sensorId);
 
     boolean existsBySensor_Id(int sensorId);
+
+    Channel findByPlaceAndChannelName(Place place, String channelName);
 }

--- a/src/main/java/live/ioteatime/apiservice/repository/MonthlyElectricityRepository.java
+++ b/src/main/java/live/ioteatime/apiservice/repository/MonthlyElectricityRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface MonthlyElectricityRepository extends JpaRepository<MonthlyElectricity, MonthlyElectricity.Pk> {
     Optional<MonthlyElectricity> findMonthlyElectricityByPk(MonthlyElectricity.Pk pk);
 
-    List<MonthlyElectricity> findAllByPkChannelIdAndPkTimeBetween(int organizationId, LocalDateTime start, LocalDateTime end);
+    List<MonthlyElectricity> findAllByPkChannelIdAndPkTimeBetween(int channelId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/live/ioteatime/apiservice/service/ElectricityService.java
+++ b/src/main/java/live/ioteatime/apiservice/service/ElectricityService.java
@@ -3,6 +3,7 @@ package live.ioteatime.apiservice.service;
 import live.ioteatime.apiservice.dto.electricity.ElectricityRequestDto;
 import live.ioteatime.apiservice.dto.electricity.ElectricityResponseDto;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ElectricityService {
@@ -13,4 +14,6 @@ public interface ElectricityService {
     ElectricityResponseDto getCurrentElectricity();
 
     ElectricityResponseDto getLastElectricity();
+
+    List<ElectricityResponseDto> getTotalElectricitiesByDate(LocalDateTime localDateTime, int organizationId);
 }

--- a/src/main/java/live/ioteatime/apiservice/service/impl/DailyElectricityServiceImpl.java
+++ b/src/main/java/live/ioteatime/apiservice/service/impl/DailyElectricityServiceImpl.java
@@ -101,6 +101,33 @@ public class DailyElectricityServiceImpl implements ElectricityService {
         return new ElectricityResponseDto(endOfDay, kwh, 0L);
     }
 
+    @Override
+    public List<ElectricityResponseDto> getTotalElectricitiesByDate(LocalDateTime localDateTime, int organizationId) {
+
+        LocalDateTime start = localDateTime.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime end = localDateTime.withHour(0).withMinute(0).withSecond(0);
+
+        Map<LocalDateTime, ElectricityResponseDto> result = new HashMap<>();
+        for (LocalDateTime date = start; !date.isAfter(end); date = date.plusDays(1)) {
+            result.put(date, new ElectricityResponseDto(date, 0L, null));
+        }
+
+        List<Place> placeList = placeRepository.findAllByOrganization_Id(organizationId);
+        for(Place place : placeList){
+            Channel channel = channelRepository.findByPlaceAndChannelName(place, "main");
+            if(channel == null) {
+                continue;
+            }
+            List<DailyElectricity> currentMonthDatas = dailyElectricityRepository.findAllByPkChannelIdAndPkTimeBetween(channel.getId(), start, end);
+                for(DailyElectricity data : currentMonthDatas) {
+                    LocalDateTime key = data.getPk().getTime();
+                    long kwh = result.get(key).getKwh();
+                    result.get(key).setKwh(kwh + data.getKwh());
+                }
+            }
+
+        return new ArrayList<>(result.values());
+    }
 
 
     // mysql에서 2달 치 일별 데이터 가져오기 이유는 월 초에는 최근 1주일치를 가져올 수 없음

--- a/src/main/java/live/ioteatime/apiservice/service/impl/DailyElectricityServiceImpl.java
+++ b/src/main/java/live/ioteatime/apiservice/service/impl/DailyElectricityServiceImpl.java
@@ -104,8 +104,8 @@ public class DailyElectricityServiceImpl implements ElectricityService {
     @Override
     public List<ElectricityResponseDto> getTotalElectricitiesByDate(LocalDateTime localDateTime, int organizationId) {
 
-        LocalDateTime start = localDateTime.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0);
-        LocalDateTime end = localDateTime.withHour(0).withMinute(0).withSecond(0);
+        LocalDateTime start = localDateTime.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime end = localDateTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
 
         Map<LocalDateTime, ElectricityResponseDto> result = new HashMap<>();
         for (LocalDateTime date = start; !date.isAfter(end); date = date.plusDays(1)) {

--- a/src/main/java/live/ioteatime/apiservice/service/impl/PredictedElectricityServiceImpl.java
+++ b/src/main/java/live/ioteatime/apiservice/service/impl/PredictedElectricityServiceImpl.java
@@ -20,7 +20,7 @@ public class PredictedElectricityServiceImpl implements PredictedElectricityServ
 
     @Override
     public List<PreciseElectricityResponseDto> getCurrentMonthPredictions(LocalDateTime requestTime) {
-        LocalDateTime start = requestTime.plusDays(1);
+        LocalDateTime start = requestTime.withHour(0).withMinute(0).withSecond(0).withNano(0).plusDays(1);
         LocalDateTime end = YearMonth.from(requestTime).atEndOfMonth().atTime(0,0,0);
         return predictedElectricityRepository.findAllByTimeBetween(start, end)
                 .stream()


### PR DESCRIPTION
이번 달 일별, 월별 총 전력 사용량 리턴하는 api입니다.
모든 채널의 전력사용량 합을 리턴합니다.

### ElecticityService 인터페이스에 메서드 추가
`List<ElectricityResponseDto> getTotalElectricitiesByDate(LocalDateTime localDateTime, int organizationId);`
- `@param` localDateTime: 요청일
- `@param` organizationId: 조직 아이디
- `@return` 요청일 기준 1일부터 요청일까지의 일별 총 전력 사용량, 요청일 기준 1월부터 요청일 전월까지의 월별 총 전력 사용량