### PR TITLE
Fix/monthly predicted values

### DIFF
--- a/http/predict.http
+++ b/http/predict.http
@@ -1,1 +1,2 @@
-GET http://localhost:8090/predicted?LocalDateTime=2024-05-11T00:00:00
+GET http://localhost:8090/predicted?requestTime=2024-05-17T00:00:00&organizationId=1
+X-USER-ID: a

--- a/src/main/java/live/ioteatime/apiservice/ApiServiceApplication.java
+++ b/src/main/java/live/ioteatime/apiservice/ApiServiceApplication.java
@@ -7,9 +7,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @SpringBootApplication
 @EnableFeignClients
 public class ApiServiceApplication {
-
-	public static void main(String[] args) {
-		SpringApplication.run(ApiServiceApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(ApiServiceApplication.class, args);
+    }
 }

--- a/src/main/java/live/ioteatime/apiservice/aop/BeforeExecuteMethodAspect.java
+++ b/src/main/java/live/ioteatime/apiservice/aop/BeforeExecuteMethodAspect.java
@@ -41,28 +41,36 @@ public class BeforeExecuteMethodAspect {
 
     @Pointcut("execution(* live.ioteatime.apiservice.controller.ModbusSensorController.*(..)) || " +
             "execution(* live.ioteatime.apiservice.controller.ModbusSensorController.*(..))")
-    public void modbusPointcut(){}
+    public void modbusPointcut() {
+    }
 
     @Pointcut("execution(* live.ioteatime.apiservice.controller.MqttSensorController.*(..)) || " +
             "execution(* live.ioteatime.apiservice.controller.TopicController.*(..))")
-    public void mqttPointcut(){}
+    public void mqttPointcut() {
+    }
 
     @Pointcut("@annotation(live.ioteatime.apiservice.annotation.VerifyOrganization)")
-    public void verifyOrganizationPointcut(){}
+    public void verifyOrganizationPointcut() {
+    }
 
 
+    @Before("verifyOrganizationPointcut() && (args(organizationId,*) || args(organizationId))")
+    public void checkOrganizationMatch(int organizationId) {
+        checkOrganizationMatchesWithUserOrganization(organizationId);
+    }
 
     /**
      * 요청 헤더의 X-USER-ID로 검색한 유저가 속한 조직과, 요청 URL PathVariable 중 sensorId로 검색한 센서가 속한 조직이 일치하는지 체크합니다.
      * 일치하지 않으면 UnAuthorizedException을 던집니다.
+     *
      * @param sensorId 센서아이디
      */
     @Before("mqttPointcut() && verifyOrganizationPointcut() && args(sensorId,*,*)")
-    public void checkOrganizationMatchFotMqtt(int sensorId){
+    public void checkOrganizationMatchFotMqtt(int sensorId) {
 
         Organization sensorOrganization = mqttSensorRepository.findById(sensorId)
                 .orElseThrow(SensorNotFoundException::new).getOrganization();
-        if(Objects.isNull(sensorOrganization)){
+        if (Objects.isNull(sensorOrganization)) {
             throw new OrganizationNotFoundException();
         }
 
@@ -71,11 +79,11 @@ public class BeforeExecuteMethodAspect {
     }
 
     @Before("modbusPointcut() && verifyOrganizationPointcut() && args(sensorId,*,*)")
-    public void checkOrganizationMatchForModbus(int sensorId){
+    public void checkOrganizationMatchForModbus(int sensorId) {
 
         Organization sensorOrganization = modbusSensorRepository.findById(sensorId)
                 .orElseThrow(SensorNotFoundException::new).getOrganization();
-        if(Objects.isNull(sensorOrganization)){
+        if (Objects.isNull(sensorOrganization)) {
             throw new OrganizationNotFoundException();
         }
 
@@ -83,11 +91,11 @@ public class BeforeExecuteMethodAspect {
     }
 
     @Before("modbusPointcut() && verifyOrganizationPointcut() && args(*,placeId,*)")
-    public void checkOrganizationMatchForPlace(int placeId){
+    public void checkOrganizationMatchForPlace(int placeId) {
 
         Organization placeOrganization = placeRepository.findById(placeId)
                 .orElseThrow(PlaceNotFoundException::new).getOrganization();
-        if(Objects.isNull(placeOrganization)){
+        if (Objects.isNull(placeOrganization)) {
             throw new OrganizationNotFoundException();
         }
 
@@ -96,35 +104,38 @@ public class BeforeExecuteMethodAspect {
 
     /**
      * http 요청의 "X-USER-ID" 헤더로 유저를 검색합니다.
+     *
      * @return User 엔티티
      */
     private User getUserFromHeader() {
         HttpServletRequest httpServletRequest =
                 ((ServletRequestAttributes) Objects.requireNonNull(RequestContextHolder.getRequestAttributes()))
                         .getRequest();
-
         String userId = httpServletRequest.getHeader("X-USER-ID");
+        if(userId == null) {
+            throw new UnauthorizedException();
+        }
         return userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
     }
 
     /**
      * 유저가 소속된 조직을 검색합니다.
+     *
      * @param user 유저 엔티티
      * @return Organization 엔티티
      */
-    private int getUserOrganizationId(User user){
+    private int getUserOrganizationId(User user) {
         Organization organization = user.getOrganization();
-        if(Objects.isNull(organization)){
+        if (Objects.isNull(organization)) {
             throw new OrganizationNotFoundException();
         }
         return organization.getId();
     }
 
-    private void checkOrganizationMatchesWithUserOrganization(int organizationId){
+    private void checkOrganizationMatchesWithUserOrganization(int organizationId) {
         int userOrgId = getUserOrganizationId(getUserFromHeader());
-        if (userOrgId != organizationId){
+        if (userOrgId != organizationId) {
             throw new UnauthorizedException();
         }
     }
-
 }

--- a/src/main/java/live/ioteatime/apiservice/controller/HourlyElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/HourlyElectricityController.java
@@ -1,6 +1,7 @@
 package live.ioteatime.apiservice.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import live.ioteatime.apiservice.annotation.VerifyOrganization;
 import live.ioteatime.apiservice.dto.electricity.PreciseElectricityResponseDto;
 import live.ioteatime.apiservice.service.HourlyElectricityService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class HourlyElectricityController {
 
     private final HourlyElectricityService hourlyElectricityService;
 
+    @VerifyOrganization
     @GetMapping("/electricities/total")
     @Operation(summary = "최근 1시간 kwh 사용량을 5분간격으로 계산하여 가져오는 API", description = "5분동안 몇kwh를 소비하였는지, 총 12개의 데이터를 반환합니다.")
     public ResponseEntity<List<PreciseElectricityResponseDto>> getOneHourTotalElectricties(@RequestParam int organizationId){

--- a/src/main/java/live/ioteatime/apiservice/controller/PredictedElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/PredictedElectricityController.java
@@ -1,5 +1,6 @@
 package live.ioteatime.apiservice.controller;
 
+import live.ioteatime.apiservice.annotation.VerifyOrganization;
 import live.ioteatime.apiservice.dto.electricity.PreciseElectricityResponseDto;
 import live.ioteatime.apiservice.service.PredictedElectricityService;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +23,12 @@ public class PredictedElectricityController {
     private final PredictedElectricityService predictedElectricityService;
 
     @GetMapping
+    @VerifyOrganization
     public ResponseEntity<List<PreciseElectricityResponseDto>> getMonthlyPredictedValues(
+            @RequestParam("organizationId") int organizationId,
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             @RequestParam("requestTime") LocalDateTime requestTime){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(predictedElectricityService.getCurrentMonthPredictions(requestTime));
+                .body(predictedElectricityService.getCurrentMonthPredictions(requestTime, organizationId));
     }
 }

--- a/src/main/java/live/ioteatime/apiservice/controller/RealtimeElectricityController.java
+++ b/src/main/java/live/ioteatime/apiservice/controller/RealtimeElectricityController.java
@@ -1,5 +1,6 @@
 package live.ioteatime.apiservice.controller;
 
+import live.ioteatime.apiservice.annotation.VerifyOrganization;
 import live.ioteatime.apiservice.dto.electricity.RealtimeElectricityResponseDto;
 import live.ioteatime.apiservice.service.RealtimeElectricityService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class RealtimeElectricityController {
 
     private final RealtimeElectricityService realtimeElectricityService;
 
+    @VerifyOrganization
     @GetMapping("/electricity")
     public ResponseEntity<List<RealtimeElectricityResponseDto>> getRealtimeElectricity(@RequestParam int organizationId){
         return ResponseEntity.ok(realtimeElectricityService.getRealtimeElectricity(organizationId));

--- a/src/main/java/live/ioteatime/apiservice/domain/PredictedDailyElectricity.java
+++ b/src/main/java/live/ioteatime/apiservice/domain/PredictedDailyElectricity.java
@@ -3,6 +3,7 @@ package live.ioteatime.apiservice.domain;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
@@ -15,4 +16,8 @@ public class PredictedDailyElectricity {
     @Id
     LocalDateTime time;
     Double kwh;
+    @Column(name = "organization_id")
+    Integer organizationId;
+    @Column(name = "channel_id")
+    Integer channelId;
 }

--- a/src/main/java/live/ioteatime/apiservice/repository/PredictedElectricityRepository.java
+++ b/src/main/java/live/ioteatime/apiservice/repository/PredictedElectricityRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 public interface PredictedElectricityRepository extends JpaRepository<PredictedDailyElectricity, LocalDateTime> {
 
-    List<PredictedDailyElectricity> findAllByTimeBetween(LocalDateTime start, LocalDateTime end);
+    List<PredictedDailyElectricity> findAllByTimeBetweenAndOrganizationIdAndChannelIdOrderByTimeAsc(
+            LocalDateTime start, LocalDateTime end, int organizationId, int channelId);
 }

--- a/src/main/java/live/ioteatime/apiservice/service/PredictedElectricityService.java
+++ b/src/main/java/live/ioteatime/apiservice/service/PredictedElectricityService.java
@@ -6,5 +6,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PredictedElectricityService {
-    List<PreciseElectricityResponseDto> getCurrentMonthPredictions(LocalDateTime requestTime);
+    List<PreciseElectricityResponseDto> getCurrentMonthPredictions(LocalDateTime requestTime, int organizationId);
 }

--- a/src/main/java/live/ioteatime/apiservice/service/impl/PredictedElectricityServiceImpl.java
+++ b/src/main/java/live/ioteatime/apiservice/service/impl/PredictedElectricityServiceImpl.java
@@ -14,15 +14,14 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PredictedElectricityServiceImpl implements PredictedElectricityService {
-
     private final PredictedElectricityRepository predictedElectricityRepository;
 
-
     @Override
-    public List<PreciseElectricityResponseDto> getCurrentMonthPredictions(LocalDateTime requestTime) {
+    public List<PreciseElectricityResponseDto> getCurrentMonthPredictions(LocalDateTime requestTime, int organizationId) {
         LocalDateTime start = requestTime.withHour(0).withMinute(0).withSecond(0).withNano(0).plusDays(1);
         LocalDateTime end = YearMonth.from(requestTime).atEndOfMonth().atTime(0,0,0);
-        return predictedElectricityRepository.findAllByTimeBetween(start, end)
+        return predictedElectricityRepository
+                .findAllByTimeBetweenAndOrganizationIdAndChannelIdOrderByTimeAsc(start, end, organizationId, -1)
                 .stream()
                 .map(data -> new PreciseElectricityResponseDto(data.getTime(), data.getKwh()))
                 .collect(Collectors.toList());

--- a/src/test/java/live/ioteatime/apiservice/controller/PredictedElectricityControllerTest.java
+++ b/src/test/java/live/ioteatime/apiservice/controller/PredictedElectricityControllerTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -56,9 +57,11 @@ class PredictedElectricityControllerTest {
 
     @Test
     void getMonthlyPredictedValues() throws Exception {
-        given(predictedElectricityService.getCurrentMonthPredictions(any())).willReturn(responseList);
+        given(predictedElectricityService.getCurrentMonthPredictions(any(), anyInt())).willReturn(responseList);
 
-        ResultActions result = mockMvc.perform(get("/predicted").param("requestTime", "2024-01-28T00:00:00"));
+        ResultActions result = mockMvc.perform(get("/predicted")
+                .param("requestTime", "2024-01-28T00:00:00")
+                .param("organizationId", "1"));
         result.andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -68,6 +71,5 @@ class PredictedElectricityControllerTest {
                 .andExpect(jsonPath("$[1].kwh").value(1972.11))
                 .andExpect(jsonPath("$[2].time").value("2024-01-31T00:00:00"))
                 .andExpect(jsonPath("$[2].kwh").value(1972.21));
-
     }
 }


### PR DESCRIPTION
## 1. `organizationId` 파라미터 추가
PredictedElectricityController.getMonthlyPredictedValues() 메서드 파라미터로
`조직아이디`가 추가되었습니다.

## 2. PredictedDailyElectricity 엔티티에 필드 추가
데이터베이스 테이블에 필드가 추가되었으므로 엔티티 코드를 수정했습니다.

## 3. 특정 핸들러 메서드에 `@VerifyOrganization` 어노테이션 붙임
요청을 보내는 유저가 자신의 조직이 아닌 다른 조직의 데이터를 조회하면 안 되기 때문에,
조직아이디를 파라미터로 받는 메서드에 커스텀 어노테이션을 붙여주었습니다.
해당 어노테이션이 붙은 경우, 요청 헤더의 X-USER-ID의 소속 조직의 아이디가 요청 파라미터의 조직아이디와 일치하는지 체크합니다.